### PR TITLE
Adding SLF4j to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <commons-io.version>2.11.0</commons-io.version>
         <log4jcore.version>2.18.0</log4jcore.version>
         <log4japi.version>2.18.0</log4japi.version>
+        <slf4j.version>2.18.0</slf4j.version>
         <orgjson.version>20220320</orgjson.version>
         <javafaker.version>1.0.2</javafaker.version>
         <seleniumdevtoolsv101.version>4.3.0</seleniumdevtoolsv101.version>
@@ -108,6 +109,16 @@
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <commons-io.version>2.11.0</commons-io.version>
         <log4jcore.version>2.18.0</log4jcore.version>
         <log4japi.version>2.18.0</log4japi.version>
-        <slf4j.version>2.18.0</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <orgjson.version>20220320</orgjson.version>
         <javafaker.version>1.0.2</javafaker.version>
         <seleniumdevtoolsv101.version>4.3.0</seleniumdevtoolsv101.version>


### PR DESCRIPTION
I noticed that, during the running of the tests, there were complaints that slf4j was missing. I don't know if that's problematic, but here's a fix to grab the most recent stable version. 