### PR TITLE
Update docker-compose-v3.yml

### DIFF
--- a/docker-compose-v3.yml
+++ b/docker-compose-v3.yml
@@ -54,6 +54,6 @@ services:
     image: bkimminich/juice-shop
     container_name: juice-shop
     ports:
-      - "3001:3001"
+      - "3000:3000"
     expose:
-      - "3001"
+      - "3000"


### PR DESCRIPTION
Port for Juice Shop appears to be incorrect. By default, bkiminich/juice-shop runs on 3000, not on 3001.

That is also the port indicated in your test suite definition, so this seems like a mistake.